### PR TITLE
减少actions报错

### DIFF
--- a/.github/workflows/publishNewFormula.yml
+++ b/.github/workflows/publishNewFormula.yml
@@ -38,9 +38,9 @@ jobs:
       - name: Git Push
         run: |
           cd homebrew-nexttrace
-          git commit -am 'Publish a new version with Formula'
+          git commit -am 'Publish a new version with Formula' || true
           git remote set-url origin https://${{ secrets.gt_token }}@github.com/xgadget-lab/homebrew-nexttrace.git
-          git push || 1
+          git push
         # env:
         #   SSH_AUTH_SOCK: /tmp/ssh_agent.sock
       - run: echo "🍏 This job's status is ${{ job.status }}."


### PR DESCRIPTION
在代码没有变化时，git commit会报错：
位于分支 main
您的分支与上游分支 'origin/main' 一致。

无文件要提交，干净的工作区