### PR TITLE
docs: update to use homebrew-core formula

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 An open source visual routing tool that pursues light weight, developed using Golang.
 
-NextTrace is part of the [OwO Network](https://github.com/OwO-Network) project. The project is a joint initiative of Leo and Vincent. 
+NextTrace is part of the [OwO Network](https://github.com/OwO-Network) project. The project is a joint initiative of Leo and Vincent.
 
 If you like this project, [Donate us](https://afdian.net/a/sjlleo/plan) to help us to provide long-lasting API cost expenses.
 
@@ -23,7 +23,7 @@ Document Language: English | [简体中文](README_zh_CN.md)
 bash -c "$(curl -Ls https://raw.githubusercontent.com/sjlleo/nexttrace/main/nt_install.sh)"
 
 # macOS brew install command
-brew tap xgadget-lab/nexttrace && brew install nexttrace
+brew install nexttrace
 
 # GHProxy Mirror (For China Mainland User)
 bash -c "$(curl -Ls https://ghproxy.com/https://raw.githubusercontent.com/sjlleo/nexttrace/main/nt_install.sh)"
@@ -221,7 +221,7 @@ Arguments:
                                      reached). Default: 30
   -d  --data-provider                Choose IP Geograph Data Provider [IP.SB,
                                      IPInfo, IPInsight, IP-API.com, Ip2region,
-                                     IPInfoLocal, CHUNZHEN, disable-geoip]. 
+                                     IPInfoLocal, CHUNZHEN, disable-geoip].
                                      Default: LeoMoeAPI
   -n  --no-rdns                      Do not resolve IP addresses to their
                                      domain names
@@ -235,7 +235,7 @@ Arguments:
                                      (RealTimePrinter ONLY)
   -t  --table                        Output trace results as table
       --raw                          An Output Easy to Parse
-  -j  --json                         Output trace results as JSON  
+  -j  --json                         Output trace results as JSON
   -c  --classic                      Classic Output trace results like
                                      BestTrace
   -f  --first                        Start from the first_ttl hop (instead from
@@ -313,7 +313,7 @@ BGP.TOOLS provided some data support for this project and we would like to expre
 
 [waiting4new](https://github.com/waiting4new)
 
-[FFEE_CO](https://github.com/fkx4-p) 
+[FFEE_CO](https://github.com/fkx4-p)
 
 ### Others
 


### PR DESCRIPTION
Since now [we have nexttrace in homebrew-core](https://github.com/Homebrew/homebrew-core/pull/132265), it would be good just to use the pre-built bottles coming with the core. :)